### PR TITLE
Add dredd docker image

### DIFF
--- a/alpine/dredd/Dockerfile
+++ b/alpine/dredd/Dockerfile
@@ -1,0 +1,11 @@
+FROM apiaryio/dredd
+MAINTAINER Nowait <devops@nowait.com>
+
+RUN apk add --no-cache make py-pip docker && pip install docker-compose && wget https://github.com/kelseyhightower/confd/releases/download/v0.11.0/confd-0.11.0-linux-amd64 && mv confd-0.11.0-linux-amd64 /bin/confd && chmod +x /bin/confd
+
+RUN mkdir /src
+WORKDIR /src
+ADD entrypoint.sh entrypoint.sh
+RUN chmod +x entrypoint.sh
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/alpine/dredd/Dockerfile
+++ b/alpine/dredd/Dockerfile
@@ -1,7 +1,7 @@
 FROM apiaryio/dredd
 MAINTAINER Nowait <devops@nowait.com>
 
-RUN apk add --no-cache make py-pip docker && pip install docker-compose && wget https://github.com/kelseyhightower/confd/releases/download/v0.11.0/confd-0.11.0-linux-amd64 && mv confd-0.11.0-linux-amd64 /bin/confd && chmod +x /bin/confd
+RUN apk add --no-cache make py-pip docker && pip install docker-compose
 
 RUN mkdir /src
 WORKDIR /src

--- a/alpine/dredd/README.md
+++ b/alpine/dredd/README.md
@@ -1,0 +1,100 @@
+## Dredd docker image
+
+This docker image is an easy way to allow services that use docker-compose to be tested via dredd.
+
+This image is opinionated in how it should be used.  The following is to describe how to properly use this image.
+
+The dredd image assumes the following
+- Makefile is mounted at /src/Makefile that declares the following targets
+  - start
+    - Target that starts the web service via docker-compose
+  - stop
+    - Target that restarts the web service with a clean dataset, most likely stopping the database container, removing it
+  - clean
+    - Stops all docker containers that started with start target and removes the containers
+
+- dredd.yml mounted at /src/dredd.yml and all files needed by dredd.yml
+
+- docker socket must be bind mounted
+
+- COMPOSE_PROJECT_NAME must be set.
+  - This ensures that the services started by docker-compose will be added to a network with the name "$COMPOSE_PROJECT_NAME_"default.  The network name must be known ahead of time so that the dredd conatiner can add itself to the network allowing dredd to make requests to the web service
+
+### Suggestions
+The hookfiles used by the dredd.yml must reset the database to a known state at the beginning of each test.  The following is an example dredd.yml, hooks.js and Makefile that accomplish this.  It is not required to use this approach but if the database is not reset to a known state at the beginning of each dredd transaction there is the potential for errors to occur relating to data state.
+
+```yml
+dry-run: null
+hookfiles: hooks.js
+language: nodejs
+sandbox: false
+server: null
+server-wait: 3
+init: false
+custom: {}
+names: false
+only: []
+reporter: []
+output: []
+header: []
+sorted: false
+user: null
+inline-errors: true
+details: false
+method: []
+color: true
+level: info
+timestamp: false
+silent: false
+path: []
+hooks-worker-timeout: 5000
+hooks-worker-connect-timeout: 1500
+hooks-worker-connect-retry: 500
+hooks-worker-after-connect-wait: 3000
+hooks-worker-term-timeout: 5000
+hooks-worker-term-retry: 500
+hooks-worker-handler-host: localhost
+hooks-worker-handler-port: 61321
+blueprint: docs/api.apib
+endpoint: "http://service:3000"
+```
+
+```Makefile
+.PHONY: stop start clean
+.IGNORE: stop start clean
+
+PWD := `pwd`
+
+start:
+  docker-compose up -d
+  docker-compose restart service
+
+stop:
+  docker-compose stop postgres
+  docker-compose rm -f postgres
+
+clean:
+  docker-compose stop
+  docker-compose rm -f
+```
+
+```js
+var hooks = require('hooks')
+var execSync = require('child_process').execSync
+
+hooks.beforeEach(function (transaction, done) {
+  // Stop the database container and remove volume to reset dataset
+  // to intial state.  When restarting the containers, there is a
+  // brief period where database connection cannot be made.  Sleeping
+  // for 2 seconds solves problem.
+  execSync('make stop')
+  execSync('make start')
+  execSync('sleep 2')
+  done()
+})
+
+hooks.afterAll(function (transactions, done) {
+  execSync('make clean')
+  done()
+})
+```

--- a/alpine/dredd/README.md
+++ b/alpine/dredd/README.md
@@ -5,18 +5,8 @@ This docker image is an easy way to allow services that use docker-compose to be
 This image is opinionated in how it should be used.  The following is to describe how to properly use this image.
 
 The dredd image assumes the following
-- Makefile is mounted at /src/Makefile that declares the following targets
-  - start
-    - Target that starts the web service via docker-compose
-  - stop
-    - Target that restarts the web service with a clean dataset, most likely stopping the database container, removing it
-  - clean
-    - Stops all docker containers that started with start target and removes the containers
-
 - dredd.yml mounted at /src/dredd.yml and all files needed by dredd.yml
-
 - docker socket must be bind mounted
-
 - COMPOSE_PROJECT_NAME must be set.
   - This ensures that the services started by docker-compose will be added to a network with the name "$COMPOSE_PROJECT_NAME_"default.  The network name must be known ahead of time so that the dredd conatiner can add itself to the network allowing dredd to make requests to the web service
 

--- a/alpine/dredd/README.md
+++ b/alpine/dredd/README.md
@@ -1,17 +1,17 @@
 ## Dredd docker image
 
-This docker image is an easy way to allow services that use docker-compose to be tested via dredd.
-
-This image is opinionated in how it should be used.  The following is to describe how to properly use this image.
+This docker image is an easy way to allow services that use docker-compose to be tested via dredd.  This image is opinionated in how it should be used.  The following is to describe how to properly use this image.
 
 The dredd image assumes the following
-- dredd.yml mounted at /src/dredd.yml and all files needed by dredd.yml
+- dredd.yml mounted at `/src/dredd.yml` and all files needed by dredd.yml
 - docker socket must be bind mounted
-- COMPOSE_PROJECT_NAME must be set.
-  - This ensures that the services started by docker-compose will be added to a network with the name "$COMPOSE_PROJECT_NAME_"default.  The network name must be known ahead of time so that the dredd conatiner can add itself to the network allowing dredd to make requests to the web service
+- `COMPOSE_PROJECT_NAME` environment variable must be set.
+  - This ensures that the services started by docker-compose will be added to a network with the name `"$COMPOSE_PROJECT_NAME_"default`.  The network name must be known ahead of time so that the dredd conatiner can add itself to the network allowing dredd to make requests to the web service
 
 ### Suggestions
 The hookfiles used by the dredd.yml must reset the database to a known state at the beginning of each test.  The following is an example dredd.yml, hooks.js and Makefile that accomplish this.  It is not required to use this approach but if the database is not reset to a known state at the beginning of each dredd transaction there is the potential for errors to occur relating to data state.
+
+Dredd.yml
 
 ```yml
 dry-run: null
@@ -49,6 +49,8 @@ blueprint: docs/api.apib
 endpoint: "http://service:3000"
 ```
 
+Makefile
+
 ```Makefile
 .PHONY: stop start clean
 .IGNORE: stop start clean
@@ -68,6 +70,7 @@ clean:
   docker-compose rm -f
 ```
 
+hooks.js
 ```js
 var hooks = require('hooks')
 var execSync = require('child_process').execSync

--- a/alpine/dredd/entrypoint.sh
+++ b/alpine/dredd/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+confd -onetime -backend env
+docker network connect "$COMPOSE_PROJECT_NAME"_default $HOSTNAME
+dredd

--- a/alpine/dredd/entrypoint.sh
+++ b/alpine/dredd/entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
 
-confd -onetime -backend env
 docker network connect "$COMPOSE_PROJECT_NAME"_default $HOSTNAME
 dredd


### PR DESCRIPTION
This PR is to create a docker image for the cli tool dredd which allows for validating an API blueprint document with the actual services implementation.
## Todo
- ~~[ ] Extend different base image?~~
- ~~[ ] Validation?~~
