### PR TITLE
Make sure confd is run in entrypoint

### DIFF
--- a/alpine/dredd/entrypoint.sh
+++ b/alpine/dredd/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 
+confd -onetime -backend env
 docker network connect "$COMPOSE_PROJECT_NAME"_default $HOSTNAME
 dredd


### PR DESCRIPTION
This is to patch the dredd docker image to make sure that confd is run in the entrypoint.
