### PR TITLE
Update php 7 composer image to install ctype and mysqli extensions

### DIFF
--- a/alpine/php/7.0/composer/Dockerfile
+++ b/alpine/php/7.0/composer/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Nowait <devops@nowait.com>
 ENV COMPOSER_VERSION=1.1.3
 
 # Currently can't install composer from a package, as it's built on php5
-RUN apk add --no-cache curl php7 php7-json php7-phar php7-ctype php7-mysqli php7-openssl php7-mbstring git && \
+RUN apk add --no-cache curl php7 php7-json php7-phar php7-dom php7-pdo php7-soap php7-ctype php7-mysqli php7-openssl php7-mbstring git && \
     curl -sS https://getcomposer.org/installer | php7 -- \
     --install-dir=/usr/local/bin --filename=composer --version=$COMPOSER_VERSION && \
     ln -sf /usr/bin/php7 /usr/bin/php && \

--- a/alpine/php/7.0/composer/Dockerfile
+++ b/alpine/php/7.0/composer/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Nowait <devops@nowait.com>
 ENV COMPOSER_VERSION=1.1.3
 
 # Currently can't install composer from a package, as it's built on php5
-RUN apk add --no-cache curl php7 php7-json php7-phar php7-openssl php7-mbstring git && \
+RUN apk add --no-cache curl php7 php7-json php7-phar php7-ctype php7-mysqli php7-openssl php7-mbstring git && \
     curl -sS https://getcomposer.org/installer | php7 -- \
     --install-dir=/usr/local/bin --filename=composer --version=$COMPOSER_VERSION && \
     ln -sf /usr/bin/php7 /usr/bin/php && \


### PR DESCRIPTION
Some apps need these php extensions or the composer install fails.
