### PR TITLE
Allow php memory limit to be configured at runtime

### DIFF
--- a/alpine/php/7.0/coverage/Dockerfile
+++ b/alpine/php/7.0/coverage/Dockerfile
@@ -10,6 +10,8 @@ RUN apk add --no-cache php7-xdebug php7-phpdbg \
 
 WORKDIR src
 
+ENV PHP_MEMORY_LIMIT="128M"
+
 COPY php.ini.default /etc/php7/conf.d/
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/alpine/php/7.0/coverage/Dockerfile
+++ b/alpine/php/7.0/coverage/Dockerfile
@@ -10,6 +10,8 @@ RUN apk add --no-cache php7-xdebug php7-phpdbg \
 
 WORKDIR src
 
-RUN echo "variables_order=EGPCS;" > /etc/php7/conf.d/00_env.ini
+COPY php.ini.default /etc/php7/conf.d/
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
-ENTRYPOINT ["phpdbg7 -qrr /src/bin/phpunit --coverage-html report/$(date +"%s")"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/alpine/php/7.0/coverage/README.md
+++ b/alpine/php/7.0/coverage/README.md
@@ -1,0 +1,23 @@
+## Php 7 Code Coverage
+
+### Getting the image
+
+```
+docker pull nowait/php:7.0-coverage
+```
+
+### Usage
+
+This docker image is very opinionated in how it must be used.  You must pass an env named `PHP_MEMORY_LIMIT` at runtime so the entrypoint templates the php.ini correctly.  Since code coverage analysis is a very memory intensive process and highly dependent on project size, this allows the same image to be used across small and large projects.  You must mount the project's source code to `/src` inside the container.  In addition, the entrypoint will pass all provided arguments to the `phpdbg7` binary inside the container, which allows for running whatever command you want with `phpdbg7`.
+
+For a typical app that uses Phpunit for the test suite the following command would generate a code coverage report.
+
+```
+docker run -e "PHP_MEMORY_LIMIT=100M" -v $(pwd):/src nowait/php:7.0-coverage -qrr /src/path/to/phpunit --coverage-html report/
+```
+
+If your application is complex and the tests depend on environment variables being defined, an env file can be used to pass these to the coverage container like so.
+
+```
+docker run --env-file=.env -e "PHP_MEMORY_LIMIT=100M" -v $(pwd):/src nowait/php:7.0-coverage -qrr /src/path/to/phpunit --coverage-html report/
+```

--- a/alpine/php/7.0/coverage/README.md
+++ b/alpine/php/7.0/coverage/README.md
@@ -8,7 +8,7 @@ docker pull nowait/php:7.0-coverage
 
 ### Usage
 
-This docker image is very opinionated in how it must be used.  You must pass an env named `PHP_MEMORY_LIMIT` at runtime so the entrypoint templates the php.ini correctly.  Since code coverage analysis is a very memory intensive process and highly dependent on project size, this allows the same image to be used across small and large projects.  You must mount the project's source code to `/src` inside the container.  In addition, the entrypoint will pass all provided arguments to the `phpdbg7` binary inside the container, which allows for running whatever command you want with `phpdbg7`.
+This docker image is very opinionated in how it must be used.  By default, the php memory limit is set to 128MB, this should be suitable for most projects.  For larger projects, you may override this default by passing an env named `PHP_MEMORY_LIMIT` at runtime.  Since code coverage analysis is a very memory intensive process and highly dependent on project size, this allows the same image to be used across small and large projects.  You must mount the project's source code to `/src` inside the container.  In addition, the entrypoint will pass all provided arguments to the `phpdbg7` binary inside the container, which allows for running whatever command you want with `phpdbg7`.
 
 For a typical app that uses Phpunit for the test suite the following command would generate a code coverage report.
 

--- a/alpine/php/7.0/coverage/entrypoint.sh
+++ b/alpine/php/7.0/coverage/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+envsubst < /etc/php7/conf.d/php.ini.default > /etc/php7/conf.d/00_env.ini
+phpdbg7 $@

--- a/alpine/php/7.0/coverage/php.ini.default
+++ b/alpine/php/7.0/coverage/php.ini.default
@@ -1,0 +1,2 @@
+variables_order = EGPCS
+memory_limit = ${PHP_MEMORY_LIMIT}


### PR DESCRIPTION
## Todo
- [x] Add default PHP_MEMORY_LIMIT so for small projects it works out of the box
