### PR TITLE
Symlink access_log to /dev/null

### DIFF
--- a/alpine/php/7.0/apache/Dockerfile
+++ b/alpine/php/7.0/apache/Dockerfile
@@ -1,9 +1,9 @@
 FROM nowait/php:7.0-cli-alpine
 MAINTAINER Nowait <devops@nowait.com>
 
-RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && \
-    apk --no-cache add 'php7-apache2<7.1' && \
-    mkdir -p /run/apache2
+RUN apk --no-cache add 'php7-apache2<7.1' && \
+    mkdir -p /run/apache2 && \
+    ln -s /dev/null /var/log/apache2/access_log 
 
 COPY apache.conf /etc/apache2/conf.d/docker.conf
 

--- a/alpine/php/7.0/cli/Dockerfile
+++ b/alpine/php/7.0/cli/Dockerfile
@@ -1,7 +1,7 @@
 FROM nowait/alpine:3.4
 MAINTAINER Nowait <devops@nowait.com>
 
-RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && \
+RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories && \
     apk --no-cache add 'php7<7.1' && \
     ln -s /usr/bin/php7 /usr/bin/php
 


### PR DESCRIPTION
We experienced issues where the apache access_log was filling up the disk space of our host machines.  When trying to rebuild the image I noticed that they did not build in their current state so I updated them to build properly.
