### PR TITLE
Fix rsyslog to have real hostname

### DIFF
--- a/ubuntu/rsyslog-logzio/Dockerfile
+++ b/ubuntu/rsyslog-logzio/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && apt-get -y -q install software-properties-common python-software-properties
 RUN add-apt-repository ppa:adiscon/v8-stable
-RUN apt-get update && apt-get -y -q install rsyslog=8.23.0-0adiscon1trusty1
+RUN apt-get update && apt-get -y -q install rsyslog
 
 RUN rm /etc/rsyslog.conf
 
@@ -16,6 +16,7 @@ RUN ln -sf /dev/stdout /var/log/syslog \
 
 ENV LOGZIO_TOKEN="sample token" \
     TYPE="TYPE" \
-    LOG_FORMAT="json"
+    LOG_FORMAT="json" \
+    HOST_HOSTNAME="test-hostname"
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/ubuntu/rsyslog-logzio/Dockerfile
+++ b/ubuntu/rsyslog-logzio/Dockerfile
@@ -16,7 +16,6 @@ RUN ln -sf /dev/stdout /var/log/syslog \
 
 ENV LOGZIO_TOKEN="sample token" \
     TYPE="TYPE" \
-    LOG_FORMAT="json" \
-    HOST_HOSTNAME="test-hostname"
+    LOG_FORMAT="json"
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/ubuntu/rsyslog-logzio/README.md
+++ b/ubuntu/rsyslog-logzio/README.md
@@ -15,7 +15,7 @@ Logzio provides two different endpoints for syslog: syslog and json format.  If 
 An example of how to run this is shown below.
 
 ```
-docker run -d -p 514:514 -e "LOGZIO_TOKEN=token" -e "TYPE=log-type" -e "LOG_FORMAT=json" nowait/rsyslog-logzio:0.4.0
+docker run -d -p 514:514 -v /etc/hostname:/etc/hostname -e "LOGZIO_TOKEN=token" -e "TYPE=log-type" -e "LOG_FORMAT=json" nowait/rsyslog-logzio:1.1
 ```
 
 You can then use the rsyslog container for the docker logging driver like so.

--- a/ubuntu/rsyslog-logzio/entrypoint.sh
+++ b/ubuntu/rsyslog-logzio/entrypoint.sh
@@ -2,6 +2,7 @@
 
 sed -i "s/%LOGZIO_TOKEN%/$LOGZIO_TOKEN/g" /etc/rsyslog.conf
 sed -i "s/%TYPE%/$TYPE/g" /etc/rsyslog.conf
+HOST_HOSTNAME=$(echo /etc/hostname)
 sed -i "s/%HOSTNAME%/$HOST_HOSTNAME/g" /etc/rsyslog.conf
 
 /usr/sbin/rsyslogd -n

--- a/ubuntu/rsyslog-logzio/entrypoint.sh
+++ b/ubuntu/rsyslog-logzio/entrypoint.sh
@@ -2,7 +2,7 @@
 
 sed -i "s/%LOGZIO_TOKEN%/$LOGZIO_TOKEN/g" /etc/rsyslog.conf
 sed -i "s/%TYPE%/$TYPE/g" /etc/rsyslog.conf
-HOST_HOSTNAME=$(echo /etc/hostname)
+HOST_HOSTNAME=$(cat /etc/hostname)
 sed -i "s/%HOSTNAME%/$HOST_HOSTNAME/g" /etc/rsyslog.conf
 
 /usr/sbin/rsyslogd -n

--- a/ubuntu/rsyslog-logzio/entrypoint.sh
+++ b/ubuntu/rsyslog-logzio/entrypoint.sh
@@ -2,5 +2,6 @@
 
 sed -i "s/%LOGZIO_TOKEN%/$LOGZIO_TOKEN/g" /etc/rsyslog.conf
 sed -i "s/%TYPE%/$TYPE/g" /etc/rsyslog.conf
+sed -i "s/%HOSTNAME%/$HOST_HOSTNAME/g" /etc/rsyslog.conf
 
 /usr/sbin/rsyslogd -n


### PR DESCRIPTION
@fhats @bobtfish this allows the rsyslog image to template the hostname in the syslog message the contents of `/etc/hostname`.  The idea is that then when you run the rsyslog container mount in the host's `/etc/hostname` file.

## Todo
- [x] tag nowait/rsyslog-logzio:1.1-test5 as nowait/rsyslog-logzio:1.1 and push