### PR TITLE
Fluentd and rsyslog

### DIFF
--- a/debian/fluentd/Dockerfile
+++ b/debian/fluentd/Dockerfile
@@ -1,0 +1,11 @@
+FROM fluent/fluentd:v0.12.35-debian-onbuild
+
+RUN mkdir -p /var/log/fluent/s3-buffer
+
+RUN chmod a+rw /var/log/fluent/s3-buffer
+
+RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev" \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends $buildDeps \
+ && sudo gem install \
+        fluent-plugin-s3

--- a/debian/fluentd/fluent.conf
+++ b/debian/fluentd/fluent.conf
@@ -1,0 +1,22 @@
+<source>
+  @type syslog
+  port 5140
+  bind 0.0.0.0
+  tag "fluentd"
+  protocol_type 'tcp'
+  format "none"  # used in combination with the 'single_value' below limits the amount of mangling that fluentd wants to do
+</source>
+
+<match **>
+  @type s3
+  path "logs"
+  s3_bucket "#{ENV['S3_BUCKET']}"
+  s3_region "us-east-1"
+  s3_object_key_format "%{path}/%{time_slice}/#{Socket.gethostname}-%{index}.%{file_extension}"
+  auto_create_bucket false
+  buffer_path /var/log/fluent/s3-buffer/
+  time_slice_format "%Y-%m-%d-%H"
+  flush_at_shutdown true
+  flush_interval '5m'   # how often fluentd rotates between chunks and uploads to s3
+  format "single_value" # works in conjunction with `format 'none'` in the syslog source to limit the output to just the message received
+</match>

--- a/ubuntu/rsyslog-logzio/rsyslog.conf
+++ b/ubuntu/rsyslog-logzio/rsyslog.conf
@@ -5,9 +5,9 @@ module(load="imudp")
 module(load="imuxsock")
 
 # rsyslog Input Modules
-input(type="imtcp" 
+input(type="imtcp"
 	 port="514")
-input(type="imudp" 
+input(type="imudp"
 	 port="514")
 
 template(name="json-tmpl"
@@ -25,3 +25,6 @@ if (getenv("LOG_FORMAT") == "json") then {
 } else {
     *.* action(type="omfwd" Target="listener.logz.io" Port="5000" Protocol="tcp" template="syslog-tmpl")
 }
+
+*.* action(type="omfwd" Target="127.0.0.1" Port="5140" Protocol="tcp")
+


### PR DESCRIPTION
This change adds a fluentd dockerfile + configuration which listens for syslog messages and archives to S3, flushing every 5 minutes.