### PR TITLE
Remove query string from apache access log to avoid PII from old clients

### DIFF
--- a/alpine/php/7.0/apache/apache.conf
+++ b/alpine/php/7.0/apache/apache.conf
@@ -1,6 +1,6 @@
 ServerName localhost
 
-LogFormat "{ \"time\":\"%t\", \"xForwardFor\":\"%{X-Forwarded-For}i\", \"clientIP\":\"%a\", \"host\":\"%V\", \"request\":\"%U\", \"query\":\"%q\", \"method\":\"%m\", \"status\":\"%>s\", \"userAgent\":\"%{User-agent}i\", \"referer\":\"%{Referer}i\" }" jsonLog
+LogFormat "{ \"time\":\"%t\", \"xForwardFor\":\"%{X-Forwarded-For}i\", \"clientIP\":\"%a\", \"host\":\"%V\", \"request\":\"%U\", \"method\":\"%m\", \"status\":\"%>s\", \"userAgent\":\"%{User-agent}i\", \"referer\":\"%{Referer}i\" }" jsonLog
 ErrorLogFormat "{ \"time\":\"%t\", \"loglevel\":\"%l\", \"pid\":\"%P\", \"filename\":\"%F\", \"errorcode\":\"%E\", \"clientIP\":\"%a\", \"xForwardFor\":\"%{X-Forwarded-For}i\", \"errormsg\":\"%M\" }"
 
 <IfModule mod_reqtimeout.c>


### PR DESCRIPTION
- [x] Rebuild image