### PR TITLE
Install net-tools in ubuntu 16.04 base image

### DIFF
--- a/ubuntu/base-image/16.04/Dockerfile
+++ b/ubuntu/base-image/16.04/Dockerfile
@@ -5,6 +5,8 @@ COPY dumb-init_1.0.1_amd64 /usr/local/bin/dumb-init
 COPY su-exec /usr/local/bin/su-exec
 COPY su-exec-entrypoint /usr/local/bin/su-exec-entrypoint
 RUN chmod +x /usr/local/bin/su-exec \
-    && chmod +x /usr/local/bin/su-exec-entrypoint
+    && chmod +x /usr/local/bin/su-exec-entrypoint \
+    && apt-get update \
+    && apt-get install net-tools -y
 
 ENTRYPOINT ["dumb-init", "--single-child"]

--- a/ubuntu/python/2.x/cli/Dockerfile
+++ b/ubuntu/python/2.x/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM nowait/ubuntu:16.04
+FROM nowait/ubuntu:16.04-1
 
 ENV PYTHONPATH=/src/vendor/lib/python2.7/site-packages:$PYTHONPATH
 

--- a/ubuntu/python/2.x/pip/Dockerfile
+++ b/ubuntu/python/2.x/pip/Dockerfile
@@ -1,4 +1,4 @@
-FROM nowait/python:2.7.12-1-cli-ubuntu
+FROM nowait/python:2.7.12-2-cli-ubuntu
 
 RUN apt-get update && \
     apt-get install -y \
@@ -8,8 +8,7 @@ RUN apt-get update && \
     libxml2-dev \
     libxslt1-dev \
     python-pip && \
-    pip install --upgrade pip && \
-    pip install six
+    pip install --upgrade pip
 
 ENTRYPOINT ["su-exec-entrypoint"]
 CMD ["pip", "-v"]


### PR DESCRIPTION
This PR adds net-tools to the base ubuntu image so that images that inherit from it can use netstat and other tools.  In addition to rebuilding all the other images I noticed that installing `six` in the pip image was causing problems.  Because our build process uses dedicated containers for installing dependencies the following was happening.

- Container A (pip container) mounts the local directory and installs pip dependencies locally.  Container A already had the six package so when pip went to decide to install it in the local directory it chose not to since it already existed globally (/usr/local/lib/python2.7/dist-packages).
- Build process for new docker image is run and copies in the directory where pip should have installed all the dependencies.
- Running a container created from the docker image crashes because the six module is missing since Contanier A never installed it to the local directory.

## Todo
- [x] push new image -- nowait/ubuntu:16.04-1
- [x] push new image -- nowait/python:2.7.12-2-cli-ubuntu
- [x] push new image -- nowait/python:2.7.12-2-pip-ubuntu