### PR TITLE
Remove su-exec-entrypoint as docker entrypoint

### DIFF
--- a/alpine/node/base/Dockerfile
+++ b/alpine/node/base/Dockerfile
@@ -44,5 +44,4 @@ EXPOSE 3000
 WORKDIR /src
 ENV PATH=/src/node_modules/.bin:$PATH
 
-ENTRYPOINT ["su-exec-entrypoint"]
 CMD ["/usr/bin/node","-v"]


### PR DESCRIPTION
These are local changes I had that never got pushed.  `su-exec-entrypoint` should be used as the default entrypoint for the npm image since it fixes permission issues when installing node modules.

This has been pushed as `nowait/node:6.11.1-base-alpine-test1` and has been used for an internal app for testing.  Once that is validated this can be `docker tag nowait/node:6.11.1-base-alpine-test1 nowait/node:6.11.1-base-alpine` and pushed.