### PR TITLE
Update to flow 0.52.0

### DIFF
--- a/alpine/flow/Dockerfile
+++ b/alpine/flow/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.6
 
-ENV FLOW_VERSION=0.50.0
+ENV FLOW_VERSION=0.52.0
 
 RUN apk add --no-cache --virtual .build-deps-flow \
      alpine-sdk \


### PR DESCRIPTION
Flow 0.52.0 was [recently released](https://github.com/facebook/flow/releases).  Trying to stay on top of releases for bug fixes and the new [linting features](https://flow.org/en/docs/linting/).